### PR TITLE
RainLab.Blog Support

### DIFF
--- a/classes/eventlisteners/RegisterSitemapGenerators.php
+++ b/classes/eventlisteners/RegisterSitemapGenerators.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Vdlp\SitemapGenerators\Classes\EventListeners;
 
 use Vdlp\SitemapGenerators\Classes\Generators\CmsPagesGenerator;
+use Vdlp\SitemapGenerators\Classes\Generators\RainLabBlogGenerator;
 use Vdlp\SitemapGenerators\Classes\Generators\RainLabPagesGenerator;
 
 final class RegisterSitemapGenerators
@@ -15,6 +16,10 @@ final class RegisterSitemapGenerators
 
         if ((bool) config('sitemapgenerators.generator_rainlab_pages_enabled', true)) {
             $generators[] = resolve(RainLabPagesGenerator::class);
+        }
+
+        if ((bool) config('sitemapgenerators.generator_rainlab_blog_enabled', true)) {
+            $generators[] = resolve(RainLabBlogGenerator::class);
         }
 
         if ((bool) config('sitemapgenerators.generator_cms_pages_enabled', true)) {

--- a/classes/generators/RainLabBlogGenerator.php
+++ b/classes/generators/RainLabBlogGenerator.php
@@ -73,6 +73,11 @@ final class RainLabBlogGenerator implements DefinitionGenerator
                 $slugParam = $this->stripTwigTags($page->attributes['blogPost']['slug'] ?? ':slug');
 
                 foreach ($posts as $post) {
+                    // only include published posts
+                    if (!$post->getAttribute('published')) {
+                        continue;
+                    }
+                    
                     $definitionUrl = str_replace($slugParam, $post->getAttribute('slug'), $url);
 
                     /** @noinspection PhpUnhandledExceptionInspection */

--- a/classes/generators/RainLabBlogGenerator.php
+++ b/classes/generators/RainLabBlogGenerator.php
@@ -14,7 +14,7 @@ use Vdlp\Sitemap\Classes\Contracts\DefinitionGenerator;
 use Vdlp\Sitemap\Classes\Dto\Definition;
 use Vdlp\Sitemap\Classes\Dto\Definitions;
 
-final class RainlabBlogGenerator implements DefinitionGenerator
+final class RainLabBlogGenerator implements DefinitionGenerator
 {
     /* @var UrlGenerator */
     private $urlGenerator;

--- a/classes/generators/RainlabBlogGenerator.php
+++ b/classes/generators/RainlabBlogGenerator.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vdlp\SitemapGenerators\Classes\Generators;
+
+use Cms\Classes\Page;
+use Cms\Classes\Theme;
+use Illuminate\Contracts\Routing\UrlGenerator;
+use Illuminate\Support\Collection;
+use RainLab\Blog\Models\Category;
+use RainLab\Blog\Models\Post;
+use Vdlp\Sitemap\Classes\Contracts\DefinitionGenerator;
+use Vdlp\Sitemap\Classes\Dto\Definition;
+use Vdlp\Sitemap\Classes\Dto\Definitions;
+
+final class RainlabBlogGenerator implements DefinitionGenerator
+{
+    /* @var UrlGenerator */
+    private $urlGenerator;
+
+    public function __construct(UrlGenerator $urlGenerator)
+    {
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    public function getDefinitions(): Definitions
+    {
+        $definitions = new Definitions();
+
+        $theme = Theme::getActiveTheme();
+
+        /** @var Collection|Category[] $categories */
+        $categories = Category::all();
+
+        /** @var Collection|Post[] $posts */
+        $posts = Post::all();
+
+        /** @var Page $page */
+        foreach ($theme->listPages() as $page) {
+            // Categories -> blog posts component
+            if (isset($page->attributes['blogPosts'])) {
+                $url = $page->attributes['url'];
+                $pageParam = $this->stripTwigTags($page->attributes['blogPosts']['pageNumber'] ?? null);
+                $categoryFilter = $this->stripTwigTags($page->attributes['blogPosts']['categoryFilter'] ?? null);
+
+                if ($categoryFilter === null) {
+                    continue;
+                }
+
+                foreach ($categories as $category) {
+                    $definitionUrl = str_replace($categoryFilter, $category->getAttribute('slug'), $url);
+
+                    if ($pageParam !== null) {
+                        $definitionUrl = $this->removeOptionalSlugParam($definitionUrl, $pageParam);
+                    }
+
+                    /** @noinspection PhpUnhandledExceptionInspection */
+                    $definitions->addItem(
+                        (new Definition)
+                            ->setUrl($this->urlGenerator->to($definitionUrl))
+                            ->setPriority(2)
+                            ->setChangeFrequency(Definition::CHANGE_FREQUENCY_MONTHLY)
+                            ->setModifiedAt($category->getAttribute('updated_at'))
+                    );
+
+                }
+            }
+
+            // Posts -> blog post component
+            if (isset($page->attributes['blogPost'])) {
+                $url = $page->attributes['url'];
+                $slugParam = $this->stripTwigTags($page->attributes['blogPost']['slug'] ?? ':slug');
+
+                foreach ($posts as $post) {
+                    $definitionUrl = str_replace($slugParam, $post->getAttribute('slug'), $url);
+
+                    /** @noinspection PhpUnhandledExceptionInspection */
+                    $definitions->addItem(
+                        (new Definition)
+                            ->setUrl($this->urlGenerator->to($definitionUrl))
+                            ->setPriority(2)
+                            ->setChangeFrequency(Definition::CHANGE_FREQUENCY_MONTHLY)
+                            ->setModifiedAt($post->getAttribute('updated_at'))
+                    );
+                }
+            }
+        }
+
+        return $definitions;
+    }
+
+    private function stripTwigTags(?string $var):? string
+    {
+        if ($var === null) {
+            return null;
+        }
+
+        $var = str_replace('{{', '', $var);
+        $var = str_replace('}}', '', $var);
+
+        return trim($var);
+    }
+
+    private function removeOptionalSlugParam(string $url, string $param): string
+    {
+        $url = str_replace('/' . $param . '?', '', $url);
+        $url = str_replace('/' . $param, '', $url);
+        return str_replace($param, '', $url);
+    }
+}

--- a/config.php
+++ b/config.php
@@ -17,6 +17,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | RainLab.Blog enabled
+    |--------------------------------------------------------------------------
+    |
+    | Enable generators for the RainLab.Blog plugin (default = true).
+    |
+    */
+
+    'generator_rainlab_blog_enabled' => (bool) env('VDLP_SITEMAP_GENERATORS_RAINLAB_BLOG_ENABLED', true),
+
+    /*
+    |--------------------------------------------------------------------------
     | Cms Pages enabled
     |--------------------------------------------------------------------------
     |

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -2,3 +2,4 @@
 1.0.1: Code improvements
 1.1.0: Update plugin dependencies
 2.0.0: "!!! Add support for PHP 7.4 or higher. Please review plugin configuration, check README.md"
+2.1.0: Support RainLab.Blog plugin


### PR DESCRIPTION
This adds support for the RainLab.Blog plugin.

It is based on the sample code provided in #2, but also adds the additional feature that only published blog posts are listed in the sitemap.